### PR TITLE
Tolk v0.99 pre-release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Historically, tolk-vscode has been cloned from [vscode-func](https://github.com/tonwhales/vscode-func)
 and completely refactored.
 
+## [0.99.0] - 2025-06-12
+
+* Sync pre-release versioning with the compiler
+
 ## [0.13.0] - 2025-05-30
 
 * Support Tolk v0.13 syntax (serialization prefixes, default parameters, lateinit variables)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "Smart contract"
     ],
     "icon": "logo.png",
-    "version": "0.13.0",
+    "version": "0.99.0",
     "engines": {
         "vscode": "^1.63.0"
     },
@@ -94,7 +94,7 @@
                         }
                     },
                     "default": {
-                        "tolkCompilerVersion": "0.13",
+                        "tolkCompilerVersion": "0.99",
                         "stdlibFolder": "/path/to/folder/stdlib-tolk"
                     }
                 },

--- a/server/src/config-scheme.ts
+++ b/server/src/config-scheme.ts
@@ -26,7 +26,7 @@ export const defaultConfig: TolkPluginConfigScheme = {
   experimentalDiagnostics: false,
   autoDetectSDK: true,
   manualSDKSettings: {
-    tolkCompilerVersion: "0.13",
+    tolkCompilerVersion: "0.99",
     stdlibFolder: "/path/to/folder/stdlib-tolk"
   }
 }


### PR DESCRIPTION
Main PR to ton-blockchain: 
* https://github.com/ton-blockchain/ton/pull/1707
 
No changes in grammar, just sync versioning with the compiler
